### PR TITLE
Allow partial type application

### DIFF
--- a/Data/Attoparsec/ByteString/Internal.hs
+++ b/Data/Attoparsec/ByteString/Internal.hs
@@ -83,8 +83,8 @@ import qualified Data.ByteString.Internal as B
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Unsafe as B
 
-type Parser a = T.Parser B.ByteString a
-type Result a = IResult B.ByteString a
+type Parser = T.Parser B.ByteString
+type Result = IResult B.ByteString
 type Input = T.Input B.ByteString
 type Added = T.Added B.ByteString
 type Failure r = T.Failure B.ByteString r

--- a/Data/Attoparsec/Text/Internal.hs
+++ b/Data/Attoparsec/Text/Internal.hs
@@ -72,8 +72,8 @@ import qualified Data.Attoparsec.Text.FastSet as Set
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as L
 
-type Parser a = T.Parser Text a
-type Result a = IResult Text a
+type Parser = T.Parser Text
+type Result = IResult Text
 type Input = T.Input Text
 type Added = T.Added Text
 type Failure r = T.Failure Text r


### PR DESCRIPTION
While patching another library (websockets) for attoparsec 0.10, I realized it's no longer possible to refer to `Data.Attoparsec.Parser` without providing a type, due to how the type synonym is created. This patch addresses the problem.
