### PR TITLE
Add peekWord8/peekChar

### DIFF
--- a/Data/Attoparsec/ByteString.hs
+++ b/Data/Attoparsec/ByteString.hs
@@ -46,6 +46,7 @@ module Data.Attoparsec.ByteString
     , I.word8
     , I.anyWord8
     , I.notWord8
+    , I.peekWord8
     , I.satisfy
     , I.satisfyWith
     , I.skip

--- a/Data/Attoparsec/ByteString/Char8.hs
+++ b/Data/Attoparsec/ByteString/Char8.hs
@@ -44,6 +44,7 @@ module Data.Attoparsec.ByteString.Char8
     , char8
     , anyChar
     , notChar
+    , peekChar
     , satisfy
 
     -- ** Special character parsers
@@ -213,6 +214,16 @@ isDigit_w8 w = w >= 48 && w <= 57
 anyChar :: Parser Char
 anyChar = satisfy $ const True
 {-# INLINE anyChar #-}
+
+-- | Match any character. Returns 'Nothing' if end of input has been
+-- reached. Does not consume any input.
+--
+-- /Note/: Because this parser does not fail, do not use it with
+-- combinators such as 'many', because such parsers loop until a
+-- failure occurs.  Careless use will thus result in an infinite loop.
+peekChar :: Parser (Maybe Char)
+peekChar = (fmap w2c) `fmap` I.peekWord8
+{-# INLINE peekChar #-}
 
 -- | Fast predicate for matching ASCII space characters.
 --

--- a/Data/Attoparsec/Text.hs
+++ b/Data/Attoparsec/Text.hs
@@ -51,6 +51,7 @@ module Data.Attoparsec.Text
     , I.satisfy
     , I.satisfyWith
     , I.skip
+    , I.peekChar
 
     -- ** Special character parsers
     , digit

--- a/tests/QC/ByteString.hs
+++ b/tests/QC/ByteString.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module QC.ByteString (tests) where
 
-import Control.Applicative ((<$>))
+import Control.Applicative ((<$>), (<*>))
 import Prelude hiding (takeWhile)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck
@@ -47,6 +47,11 @@ notWord8 w (NonEmpty s) = maybeP (P.notWord8 w) bs == if v == w
                                                       else Just v
     where v = L.head bs
           bs = L.pack s
+
+peekWord8 s
+    | L.null s  = p == Just (Nothing, s)
+    | otherwise = p == Just (Just (L.head s), s)
+  where p = maybeP ((,) <$> P.peekWord8 <*> P.takeLazyByteString) s
 
 string s t = maybeP (P.string s') (s `L.append` t) == Just s'
   where s' = toStrict s
@@ -94,6 +99,7 @@ tests = [
     testProperty "word8" word8,
     testProperty "notWord8" notWord8,
     testProperty "anyWord8" anyWord8,
+    testProperty "peekWord8" peekWord8,
     testProperty "string" string,
     testProperty "skipWhile" skipWhile,
     testProperty "takeCount" takeCount,

--- a/tests/QC/Text.hs
+++ b/tests/QC/Text.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module QC.Text (tests) where
 
-import Control.Applicative ((<$>))
+import Control.Applicative ((<$>), (<*>))
 import Prelude hiding (takeWhile)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck
@@ -47,6 +47,11 @@ notChar w (NonEmpty s) = maybeP (P.notChar w) bs == if v == w
                                                       else Just v
     where v = L.head bs
           bs = L.pack s
+
+peekChar s
+    | L.null s  = p == Just (Nothing, s)
+    | otherwise = p == Just (Just (L.head s), s)
+  where p = maybeP ((,) <$> P.peekChar <*> P.takeLazyText) s
 
 string s t = maybeP (P.string s') (s `L.append` t) == Just s'
   where s' = toStrict s
@@ -97,6 +102,7 @@ tests = [
     testProperty "char" char,
     testProperty "notChar" notChar,
     testProperty "anyChar" anyChar,
+    testProperty "peekChar" peekChar,
     testProperty "string" string,
     testProperty "stringCI" stringCI,
     testProperty "skipWhile" skipWhile,


### PR DESCRIPTION
While these new functions don't allow you to express something new, they make it more efficient (and perhaps more natural) to express committed choice. For example, if you want to parse a CSV field, which may be surrounded by double quotes, you can now do:

``` haskell
field = do
    mb <- peekWord8
    case mb of
        Just b | b == doubleQuote -> quotedField
        _ -> regularField
```

Using `quotedField <|> regularField` would be incorrect as once we've seen the initial double quote, we want to commit to the `quotedField` path. You could achieve the same effect by using `word8`, but then you'd be forced to cons the byte back onto the string in the `regularField` case, causing an extra copy.
