### PR TITLE
Strict versions of list-producing combinators

### DIFF
--- a/Data/Attoparsec/Combinator.hs
+++ b/Data/Attoparsec/Combinator.hs
@@ -14,10 +14,15 @@ module Data.Attoparsec.Combinator
       choice
     , count
     , option
+    , many'
     , many1
+    , many1'
     , manyTill
+    , manyTill'
     , sepBy
+    , sepBy'
     , sepBy1
+    , sepBy1'
     , skipMany
     , skipMany1
     , eitherP
@@ -60,6 +65,20 @@ option x p = p <|> pure x
 {-# SPECIALIZE option :: a -> Z.Parser a -> Z.Parser a #-}
 #endif
 
+-- | @many' p@ applies the action @p@ /zero/ or more times. Returns a
+-- list of the returned values of @p@. The value returned by @p@ is
+-- forced to WHNF.
+--
+-- >  word  = many' letter
+many' :: (Alternative f, Monad f) => f a -> f [a]
+many' p = many_p
+  where many_p = some_p <|> pure []
+        some_p = do
+            !a <- p
+            as <- many_p
+            return (a : as)
+{-# INLINE many' #-}
+
 -- | @many1 p@ applies the action @p@ /one/ or more times. Returns a
 -- list of the returned values of @p@.
 --
@@ -67,6 +86,18 @@ option x p = p <|> pure x
 many1 :: Alternative f => f a -> f [a]
 many1 p = liftA2 (:) p (many p)
 {-# INLINE many1 #-}
+
+-- | @many1' p@ applies the action @p@ /one/ or more times. Returns a
+-- list of the returned values of @p@. The value returned by @p@ is
+-- forced to WHNF.
+--
+-- >  word  = many1' letter
+many1' :: (Alternative f, Monad f) => f a -> f [a]
+many1' p = do
+    !a <- p
+    as <- many' p
+    return (a : as)
+{-# INLINE many1' #-}
 
 -- | @sepBy p sep@ applies /zero/ or more occurrences of @p@, separated
 -- by @sep@. Returns a list of the values returned by @p@.
@@ -81,10 +112,29 @@ sepBy p s = liftA2 (:) p ((s *> sepBy1 p s) <|> pure []) <|> pure []
 {-# SPECIALIZE sepBy :: Z.Parser a -> Z.Parser s -> Z.Parser [a] #-}
 #endif
 
+-- | @sepBy' p sep@ applies /zero/ or more occurrences of @p@, separated
+-- by @sep@. Returns a list of the values returned by @p@. The value
+-- returned by @p@ is forced to WHNF.
+--
+-- > commaSep p  = p `sepBy'` (symbol ",")
+sepBy' :: (Alternative f, Monad f) => f a -> f s -> f [a]
+sepBy' p s = scan <|> pure []
+  where
+    scan = do
+        !a <- p
+        as <- (s *> sepBy1' p s) <|> pure []
+        return (a : as)
+#if __GLASGOW_HASKELL__ >= 700
+{-# SPECIALIZE sepBy' :: Parser ByteString a -> Parser ByteString s
+                      -> Parser ByteString [a] #-}
+{-# SPECIALIZE sepBy' :: Parser Text a -> Parser Text s -> Parser Text [a] #-}
+{-# SPECIALIZE sepBy' :: Z.Parser a -> Z.Parser s -> Z.Parser [a] #-}
+#endif
+
 -- | @sepBy1 p sep@ applies /one/ or more occurrences of @p@, separated
 -- by @sep@. Returns a list of the values returned by @p@.
 --
--- > commaSep p  = p `sepBy` (symbol ",")
+-- > commaSep p  = p `sepBy1` (symbol ",")
 sepBy1 :: Alternative f => f a -> f s -> f [a]
 sepBy1 p s = scan
     where scan = liftA2 (:) p ((s *> scan) <|> pure [])
@@ -93,6 +143,23 @@ sepBy1 p s = scan
                       -> Parser ByteString [a] #-}
 {-# SPECIALIZE sepBy1 :: Parser Text a -> Parser Text s -> Parser Text [a] #-}
 {-# SPECIALIZE sepBy1 :: Z.Parser a -> Z.Parser s -> Z.Parser [a] #-}
+#endif
+
+-- | @sepBy1' p sep@ applies /one/ or more occurrences of @p@, separated
+-- by @sep@. Returns a list of the values returned by @p@. The value
+-- returned by @p@ is forced to WHNF.
+--
+-- > commaSep p  = p `sepBy1'` (symbol ",")
+sepBy1' :: (Alternative f, Monad f) => f a -> f s -> f [a]
+sepBy1' p s = scan
+    where scan = do !a <- p
+                    as <- (s *> scan) <|> pure []
+                    return (a : as)
+#if __GLASGOW_HASKELL__ >= 700
+{-# SPECIALIZE sepBy1' :: Parser ByteString a -> Parser ByteString s
+                       -> Parser ByteString [a] #-}
+{-# SPECIALIZE sepBy1' :: Parser Text a -> Parser Text s -> Parser Text [a] #-}
+{-# SPECIALIZE sepBy1' :: Z.Parser a -> Z.Parser s -> Z.Parser [a] #-}
 #endif
 
 -- | @manyTill p end@ applies action @p@ /zero/ or more times until
@@ -111,6 +178,29 @@ manyTill p end = scan
                         -> Parser ByteString [a] #-}
 {-# SPECIALIZE manyTill :: Parser Text a -> Parser Text b -> Parser Text [a] #-}
 {-# SPECIALIZE manyTill :: Z.Parser a -> Z.Parser b -> Z.Parser [a] #-}
+#endif
+
+-- | @manyTill' p end@ applies action @p@ /zero/ or more times until
+-- action @end@ succeeds, and returns the list of values returned by
+-- @p@.  This can be used to scan comments:
+--
+-- >  simpleComment   = string "<!--" *> manyTill' anyChar (try (string "-->"))
+--
+-- Note the overlapping parsers @anyChar@ and @string \"<!--\"@, and
+-- therefore the use of the 'try' combinator. The value returned by @p@
+-- is forced to WHNF.
+manyTill' :: (Alternative f, Monad f) => f a -> f b -> f [a]
+manyTill' p end = scan
+    where scan = (end *> pure []) <|> scan'
+          scan' = do
+              !a <- p
+              as <- scan
+              return (a : as)
+#if __GLASGOW_HASKELL__ >= 700
+{-# SPECIALIZE manyTill' :: Parser ByteString a -> Parser ByteString b
+                         -> Parser ByteString [a] #-}
+{-# SPECIALIZE manyTill' :: Parser Text a -> Parser Text b -> Parser Text [a] #-}
+{-# SPECIALIZE manyTill' :: Z.Parser a -> Z.Parser b -> Z.Parser [a] #-}
 #endif
 
 -- | Skip zero or more instances of an action.


### PR DESCRIPTION
These allow programmers to avoid space leaks, due to thunks of parsers building up in the returned list.

I managed to remove several 100 MBs of thunks by using these in cassava.
