### PR TITLE
Fix Int overflow in lengthAtLeast

### DIFF
--- a/Data/Attoparsec/Text/Internal.hs
+++ b/Data/Attoparsec/Text/Internal.hs
@@ -96,7 +96,7 @@ instance IsString (Parser Text) where
     fromString = string . T.pack
 
 lengthAtLeast :: T.Text -> Int -> Bool
-lengthAtLeast t@(T.Text _ _ l) n = l >= n * 4 || T.length t >= n
+lengthAtLeast t@(T.Text _ _ len) n = (len `div` 2) >= n || T.length t >= n
 {-# INLINE lengthAtLeast #-}
 
 -- | If at least @n@ characters of input are available, return the


### PR DESCRIPTION
In addition, the prior check assumed that the length was in bytes, not
Word16s, which made it too conservative.
