### PR TITLE
Fix exponential compilation times due to inlining

### DIFF
--- a/Data/Attoparsec/ByteString/Internal.hs
+++ b/Data/Attoparsec/ByteString/Internal.hs
@@ -85,13 +85,9 @@ import qualified Data.ByteString.Unsafe as B
 
 #if defined(__GLASGOW_HASKELL__)
 import GHC.Base (realWorld#)
-import GHC.Exts (inline)
 import GHC.IO (IO(IO))
 #else
 import System.IO.Unsafe (unsafePerformIO)
-
-inline :: a -> a
-inline x = x
 #endif
 
 type Parser = T.Parser B.ByteString
@@ -116,9 +112,7 @@ ensure' !n0 i0 a0 m0 kf0 ks0 =
 ensure :: Int -> Parser B.ByteString
 ensure !n = T.Parser $ \i0 a0 m0 kf ks ->
     if B.length (unI i0) >= n
-    -- Inline the success continuation to avoid creating a closure in
-    -- the common case of enough data in the buffer:
-    then inline ks i0 a0 m0 (unI i0)
+    then ks i0 a0 m0 (unI i0)
     -- The uncommon case is kept out-of-line to reduce code size:
     else ensure' n i0 a0 m0 kf ks
 -- Non-recursive so the bounds check can be inlined:

--- a/Data/Attoparsec/Text/Internal.hs
+++ b/Data/Attoparsec/Text/Internal.hs
@@ -78,13 +78,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Internal as T
 import qualified Data.Text.Lazy as L
 
-#if defined(__GLASGOW_HASKELL__)
-import GHC.Exts (inline)
-#else
-inline :: a -> a
-inline x = x
-#endif
-
 type Parser = T.Parser Text
 type Result = IResult Text
 type Input = T.Input Text
@@ -104,7 +97,7 @@ lengthAtLeast t@(T.Text _ _ len) n = (len `div` 2) >= n || T.length t >= n
 ensure :: Int -> Parser Text
 ensure !n = T.Parser $ \i0 a0 m0 kf ks ->
     if lengthAtLeast (unI i0) n
-    then inline ks i0 a0 m0 (unI i0)
+    then ks i0 a0 m0 (unI i0)
     else runParser (demandInput >> go n) i0 a0 m0 kf ks
   where
     go n' = T.Parser $ \i0 a0 m0 kf ks ->


### PR DESCRIPTION
Always inlining the success continuation helps performance but explodes
the code size so that compiling even small examples such as calling
anyWord8 16 times in a row slows to a crawl.

Fixes #38
