### PR TITLE
Add parser for real numbers which accepts more inputs

### DIFF
--- a/Data/Attoparsec/Text.hs
+++ b/Data/Attoparsec/Text.hs
@@ -106,7 +106,7 @@ module Data.Attoparsec.Text
     , I.atEnd
     ) where
 
-import Control.Applicative ((<$>), (<*>), (*>), (<*), (<|>))
+import Control.Applicative ((<$>), (<$), (<*>), (*>), (<*), (<|>))
 import Data.Attoparsec.Combinator
 import Data.Attoparsec.Number (Number(..))
 import Data.Attoparsec.Text.Internal ((<?>), Parser, Result, parse, takeWhile1)
@@ -495,7 +495,9 @@ laxFloaty :: Fractional a => (Integer -> Integer -> Integer -> a) -> Parser a
 {-# INLINE laxFloaty #-}
 laxFloaty f = do
   !positive     <- floatyPositive
-  (!real,!frac) <-  (,) <$> decimal  <*> (tryFraction <|> return (T 0 0))
+  (!real,!frac) <-  (,) <$> decimal  <*> (  tryFraction
+                                        <|> T 0 0 <$ I.char '.'
+                                        <|> return (T 0 0))
                 <|> (,) <$> return 0 <*>  tryFraction
   power         <- floatyPower
   let n = finiFloaty f real frac power

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -85,6 +85,8 @@ test-suite tests
     QuickCheck >= 2.4,
     test-framework >= 0.4,
     test-framework-quickcheck2 >= 0.2,
+    HUnit,
+    test-framework-hunit,
     text
 
 benchmark benchmarks

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -81,6 +81,16 @@ main = do
        bench "short" $ nf (AB.parse quotedString) (BC.pack "abcdefghijk\"")
      , bench "long" $ nf (AB.parse quotedString) b
      ]
+   , bgroup "number" [
+       bench "double 12.2"      $ nf (AB.parse AC.double) (BC.pack "11.2"  )
+     , bench "double 12.23"     $ nf (AB.parse AC.double) (BC.pack "11.23" )
+     , bench "double 12.234"    $ nf (AB.parse AC.double) (BC.pack "11.234")
+     , bench "double 12.2e4"    $ nf (AB.parse AC.double) (BC.pack "11.2e4")
+     , bench "laxDouble 12.2"   $ nf (AB.parse AC.laxDouble) (BC.pack "11.2"  )
+     , bench "laxDouble 12.23"  $ nf (AB.parse AC.laxDouble) (BC.pack "11.23" )
+     , bench "laxDouble 12.234" $ nf (AB.parse AC.laxDouble) (BC.pack "11.234")
+     , bench "laxDouble 12.2e4" $ nf (AB.parse AC.laxDouble) (BC.pack "11.2e4")
+     ]
    ]
 
 -- Benchmarks bind and (potential) bounds-check merging.


### PR DESCRIPTION
New parsers accept numbers which have leading or trailing dot. For example: 

```
"1."   == 1.0 - trailing dot
".23"  == 0.23 - leading dot
"-0.3" == -0.3
```

Such numbers appear in the wild so it makes sense to have parsers for them.