### PR TITLE
Add the optionMaybe combinator

### DIFF
--- a/Data/Attoparsec/Combinator.hs
+++ b/Data/Attoparsec/Combinator.hs
@@ -14,6 +14,7 @@ module Data.Attoparsec.Combinator
       choice
     , count
     , option
+    , optionMaybe
     , many'
     , many1
     , many1'
@@ -65,6 +66,18 @@ option x p = p <|> pure x
 {-# SPECIALIZE option :: a -> Parser Text a -> Parser Text a #-}
 {-# SPECIALIZE option :: a -> Z.Parser a -> Z.Parser a #-}
 #endif
+
+-- | @option@ specialized to @Maybe@. @optionMaybe p@ tries to apply
+-- action @p@. If @p@ fails without consuming input, it returns
+-- @Nothing@, otherwise @Just@ the value returned by @p@.
+--
+-- > mDecimal :: Integral a => Parser (Maybe a)
+-- > mDecimal = optionMaybe decimal
+optionMaybe :: Alternative f => f a -> f (Maybe a)
+optionMaybe = option Nothing . fmap Just
+{-# SPECIALIZE optionMaybe :: Parser ByteString a -> Parser ByteString (Maybe a) #-}
+{-# SPECIALIZE optionMaybe :: Parser Text a -> Parser Text (Maybe a) #-}
+{-# SPECIALIZE optionMaybe :: Z.Parser a -> Z.Parser (Maybe a) #-}
 
 -- | A version of 'liftM2' that is strict in the result of its first
 -- action.


### PR DESCRIPTION
I found myself needing this combinator in multiple locations, so I added it to attoparsec. 

Originally I named it mOption, but when I realized that parsec provided an identical combinator called optionMaybe, I renamed it to match parsec. 
