### PR TITLE
Improve performance of numeric parsers by parsing to Scientific numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.hi
 *.o
 /dist/
+.cabal-sandbox
+cabal.sandbox.config

--- a/Data/Attoparsec/Number.hs
+++ b/Data/Attoparsec/Number.hs
@@ -10,10 +10,7 @@
 --
 -- A simple number type, useful for parsing both exact and inexact
 -- quantities without losing much precision.
-module Data.Attoparsec.Number
-    (
-      Number(..)
-    ) where
+module Data.Attoparsec.Number ( Number(..) ) where
 
 import Control.DeepSeq (NFData(rnf))
 import Data.Data (Data)

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -43,7 +43,8 @@ library
                  bytestring,
                  containers,
                  deepseq,
-                 text >= 0.11.1.5
+                 text >= 0.11.1.5,
+                 scientific >= 0.0 && < 0.1
 
   exposed-modules: Data.Attoparsec
                    Data.Attoparsec.ByteString

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -81,6 +81,60 @@ main = do
        bench "short" $ nf (AB.parse quotedString) (BC.pack "abcdefghijk\"")
      , bench "long" $ nf (AB.parse quotedString) b
      ]
+
+   , let strN     = "1234.56789"
+         strNePos = "1234.56789e3"
+         strNeNeg = "1234.56789e-3"
+     in
+     bgroup "numbers"
+     [ let !tN     = T.pack strN
+           !tNePos = T.pack strNePos
+           !tNeNeg = T.pack strNeNeg
+       in bgroup "Text"
+       [
+         bgroup "no power"
+         [ bench "double"     $ nf (AT.parseOnly AT.double)                            tN
+         , bench "number"     $ nf (AT.parseOnly AT.number)                            tN
+         , bench "rational"   $ nf (AT.parseOnly (AT.rational :: AT.Parser Rational))  tN
+         , bench "scientific" $ nf (AT.parseOnly (AT.rational :: AT.Parser Scientifc)) tN
+         ]
+       , bgroup "positive power"
+         [ bench "double"     $ nf (AT.parseOnly AT.double)                            tNePos
+         , bench "number"     $ nf (AT.parseOnly AT.number)                            tNePos
+         , bench "rational"   $ nf (AT.parseOnly (AT.rational :: AT.Parser Rational))  tNePos
+         , bench "scientific" $ nf (AT.parseOnly (AT.rational :: AT.Parser Scientifc)) tNePos
+         ]
+       , bgroup "negative power"
+         [ bench "double"     $ nf (AT.parseOnly AT.double)                            tNeNeg
+         , bench "number"     $ nf (AT.parseOnly AT.number)                            tNeNeg
+         , bench "rational"   $ nf (AT.parseOnly (AT.rational :: AT.Parser Rational))  tNeNeg
+         , bench "scientific" $ nf (AT.parseOnly (AT.rational :: AT.Parser Scientifc)) tNeNeg
+         ]
+       ]
+     , let !bN     = BC.pack strN
+           !bNePos = BC.pack strNePos
+           !bNeNeg = BC.pack strNeNeg
+       in bgroup "ByteString"
+       [ bgroup "no power"
+         [ bench "double"     $ nf (AC.parseOnly AC.double)                             bN
+         , bench "number"     $ nf (AC.parseOnly AC.number)                             bN
+         , bench "rational"   $ nf (AC.parseOnly (AC.rational :: AC.Parser Rational))   bN
+         , bench "scientific" $ nf (AC.parseOnly (AC.rational :: AC.Parser Scientific)) bN
+         ]
+       , bgroup "positive power"
+         [ bench "double"     $ nf (AC.parseOnly AC.double)                             bNePos
+         , bench "number"     $ nf (AC.parseOnly AC.number)                             bNePos
+         , bench "rational"   $ nf (AC.parseOnly (AC.rational :: AC.Parser Rational))   bNePos
+         , bench "scientific" $ nf (AC.parseOnly (AC.rational :: AC.Parser Scientific)) bNePos
+         ]
+       , bgroup "negative power"
+         [ bench "double"     $ nf (AC.parseOnly AC.double)                             bNeNeg
+         , bench "number"     $ nf (AC.parseOnly AC.number)                             bNeNeg
+         , bench "rational"   $ nf (AC.parseOnly (AC.rational :: AC.Parser Rational))   bNeNeg
+         , bench "scientific" $ nf (AC.parseOnly (AC.rational :: AC.Parser Scientific)) bNeNeg
+         ]
+       ]
+     ]
    ]
 
 -- Benchmarks bind and (potential) bounds-check merging.

--- a/benchmarks/attoparsec-benchmarks.cabal
+++ b/benchmarks/attoparsec-benchmarks.cabal
@@ -13,6 +13,6 @@ executable attoparsec-benchmarks
     base,
     bytestring,
     criterion >= 0.5,
-    deepseq == 1.1.*,
+    deepseq >= 1.1,
     parsec >= 3.1.2,
     text


### PR DESCRIPTION
Hi Bryan,

Here's something for you to chew on. This was discussed in #50.

It refactors the numeric parsers to use the `Scientific` type from the `scientific` package I just [released](http://hackage.haskell.org/package/scientific).

This will be needed by my pull request to change the `Number` type in `aeson` to use the `Scientific` type instead: https://github.com/bos/aeson/pull/156

Let me know if you think these changes make sense or not.
