### PR TITLE
Make all cabal flags manual

### DIFF
--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -36,6 +36,7 @@ extra-source-files:
 Flag developer
   Description: Whether to build the library in development mode
   Default: False
+  Manual: True
 
 library
   build-depends: array,


### PR DESCRIPTION
This means that dependency solver's job is easier (it doesn't need to
consider the opposite flag setting) and it means that cabal cannot
automatically switch these flags (which I don't think happened in the
past, but it's theoretically possible).
