### PR TITLE
Remove benchmark section from cabal file

### DIFF
--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -87,19 +87,6 @@ test-suite tests
     test-framework-quickcheck2 >= 0.2,
     text
 
-benchmark benchmarks
-  type: exitcode-stdio-1.0
-  hs-source-dirs: benchmarks
-  main-is: Benchmarks.hs
-  build-depends:
-    attoparsec,
-    base,
-    bytestring,
-    criterion >= 0.5,
-    deepseq >= 1.1,
-    parsec >= 3.1.2,
-    text
-
 source-repository head
   type:     git
   location: https://github.com/bos/attoparsec


### PR DESCRIPTION
`cabal bench` does not work, because `criterion` indirectly depends on
attoparsec.  So building the benchmark executable fails because we end
up with to different versions of attoparsec (the in-place version and
the installed one that criterion depends on...).
