### PR TITLE
Better errors

### DIFF
--- a/Data/Attoparsec/ByteString.hs
+++ b/Data/Attoparsec/ByteString.hs
@@ -36,7 +36,7 @@ module Data.Attoparsec.ByteString
 
     -- ** Result conversion
     , maybeResult
-    , eitherResult
+    , I.eitherResult
 
     -- * Parsing individual bytes
     , I.word8
@@ -214,10 +214,3 @@ parseWith refill p s = step $ parse p s
 maybeResult :: Result r -> Maybe r
 maybeResult (T.Done _ r) = Just r
 maybeResult _            = Nothing
-
--- | Convert a 'Result' value to an 'Either' value. A 'T.Partial'
--- result is treated as failure.
-eitherResult :: Result r -> Either String r
-eitherResult (T.Done _ r)     = Right r
-eitherResult (T.Fail _ _ msg) = Left msg
-eitherResult _                = Left "Result: incomplete input"

--- a/Data/Attoparsec/ByteString/Internal.hs
+++ b/Data/Attoparsec/ByteString/Internal.hs
@@ -74,6 +74,7 @@ import Data.Attoparsec.Internal
 import Data.Attoparsec.Internal.Fhthagn (inlinePerformIO)
 import Data.Attoparsec.Internal.Types hiding (Parser, Failure, Success)
 import Data.ByteString (ByteString)
+import Data.List (intercalate)
 import Data.Word (Word8)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Ptr (castPtr, minusPtr, plusPtr)
@@ -416,7 +417,8 @@ parse m s = T.runParser m (buffer s) (Pos 0) Incomplete failK successK
 -- @
 parseOnly :: Parser a -> ByteString -> Either String a
 parseOnly m s = case T.runParser m (buffer s) (Pos 0) Complete failK successK of
-                  Fail _ _ err -> Left err
+                  Fail input errs err -> let msg = errs ++ [err, "attoparsec failed on input:", B.unpack input]
+                                         in Left . (++ "\n") . intercalate "\n" $ msg
                   Done _ a     -> Right a
                   _            -> error "parseOnly: impossible error!"
 {-# INLINE parseOnly #-}

--- a/Data/Attoparsec/ByteString/Internal.hs
+++ b/Data/Attoparsec/ByteString/Internal.hs
@@ -417,10 +417,13 @@ parse m s = T.runParser m (buffer s) (Pos 0) Incomplete failK successK
 -- @
 parseOnly :: Parser a -> ByteString -> Either String a
 parseOnly m s = case T.runParser m (buffer s) (Pos 0) Complete failK successK of
-                  Fail input errs err -> let msg = errs ++ [err, "attoparsec failed on input:", B.unpack input]
+                  Fail input errs err -> let msg = errs ++ err :
+                                                   "attoparsec failed on input:" :
+                                                   B.unpack input :
+                                                   []
                                          in Left . (++ "\n") . intercalate "\n" $ msg
-                  Done _ a     -> Right a
-                  _            -> error "parseOnly: impossible error!"
+                  Done _ a            -> Right a
+                  _                   -> error "parseOnly: impossible error!"
 {-# INLINE parseOnly #-}
 
 get :: Parser ByteString

--- a/Data/Attoparsec/ByteString/Internal.hs
+++ b/Data/Attoparsec/ByteString/Internal.hs
@@ -429,7 +429,7 @@ eitherResult :: Result r -> Either String r
 eitherResult (T.Done _ r)     = Right r
 eitherResult (T.Fail input contexts msg) =
     Left . intercalate "\n" $
-        contexts ++ [msg, "attoparsec failed on input:", B.unpack input, ""]
+        contexts ++ [msg, "length of remaining input: " ++ show (B.length input), ""]
 eitherResult _                = Left "Result: incomplete input"
 
 get :: Parser ByteString

--- a/Data/Attoparsec/ByteString/Internal.hs
+++ b/Data/Attoparsec/ByteString/Internal.hs
@@ -427,10 +427,8 @@ parseOnly m s = case T.runParser m (buffer s) (Pos 0) Complete failK successK of
 -- result is treated as failure.
 eitherResult :: Result r -> Either String r
 eitherResult (T.Done _ r)     = Right r
-eitherResult (T.Fail input contexts msg) =
-    Left . intercalate "\n" $
-        contexts ++ [msg, "length of remaining input: " ++ show (B.length input), ""]
-eitherResult _                = Left "Result: incomplete input"
+eitherResult (T.Fail input contexts msg) = Left . intercalate "\n" $ contexts ++ [msg, ""]
+eitherResult _ = Left "Result: incomplete input"
 
 get :: Parser ByteString
 get = T.Parser $ \t pos more _lose succ ->

--- a/Data/Attoparsec/ByteString/Lazy.hs
+++ b/Data/Attoparsec/ByteString/Lazy.hs
@@ -37,7 +37,7 @@ module Data.Attoparsec.ByteString.Lazy
 import Control.DeepSeq (NFData(rnf))
 import Data.ByteString.Lazy.Internal (ByteString(..), chunk)
 import Data.List (intercalate)
-import Data.ByteString.Lazy.Char8 (unpack)
+import qualified Data.ByteString.Lazy.Char8 as BL (length)
 import qualified Data.ByteString as B
 import qualified Data.Attoparsec.ByteString as A
 import qualified Data.Attoparsec.Internal.Types as T
@@ -102,6 +102,5 @@ maybeResult _          = Nothing
 -- | Convert a 'Result' value to an 'Either' value.
 eitherResult :: Result r -> Either String r
 eitherResult (Done _ r)     = Right r
-eitherResult (Fail input contexts msg) =
-    Left . intercalate "\n" $
-        contexts ++ [msg, "attoparsec failed on input:", unpack input, ""]
+eitherResult (Fail _ contexts msg) =
+    Left . intercalate "\n" $ contexts ++ [msg, ""]

--- a/Data/Attoparsec/ByteString/Lazy.hs
+++ b/Data/Attoparsec/ByteString/Lazy.hs
@@ -36,6 +36,8 @@ module Data.Attoparsec.ByteString.Lazy
 
 import Control.DeepSeq (NFData(rnf))
 import Data.ByteString.Lazy.Internal (ByteString(..), chunk)
+import Data.List (intercalate)
+import Data.ByteString.Lazy.Char8 (unpack)
 import qualified Data.ByteString as B
 import qualified Data.Attoparsec.ByteString as A
 import qualified Data.Attoparsec.Internal.Types as T
@@ -100,4 +102,6 @@ maybeResult _          = Nothing
 -- | Convert a 'Result' value to an 'Either' value.
 eitherResult :: Result r -> Either String r
 eitherResult (Done _ r)     = Right r
-eitherResult (Fail _ _ msg) = Left msg
+eitherResult (Fail input contexts msg) =
+    Left . intercalate "\n" $
+        contexts ++ [msg, "attoparsec failed on input:", unpack input, ""]

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -1,5 +1,5 @@
 name:            attoparsec
-version:         0.12.1.0
+version:         0.12.2.0
 license:         BSD3
 license-file:    LICENSE
 category:        Text, Parsing

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -1,5 +1,5 @@
 name:            attoparsec
-version:         0.12.2.1
+version:         0.12.2.0
 license:         BSD3
 license-file:    LICENSE
 category:        Text, Parsing

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 0.12.2.0
 
-* Add contexts and unconsumed errors to parseOnly's Left values
+* Add contexts and unconsumed errors to Left values in eitherResult, parseOnly
 
 0.12.1.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,3 @@
-0.12.2.0
-
-* Add contexts and unconsumed errors to Left values in eitherResult, parseOnly
-
 0.12.1.0
 
 * Now compatible with GHC 7.9

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+0.12.2.0
+
+* Add contexts and unconsumed errors to parseOnly's Left values
+
 0.12.1.0
 
 * Now compatible with GHC 7.9


### PR DESCRIPTION
Change the Left value to contain all of IResult's information.

I am pretty sure this has no performance impact unless somebody forces the Left value (in which case the cost of computing the error message should be very well justified).

This should help with #49.