### PR TITLE
Change the Show instances for Result and IResult

### DIFF
--- a/Data/Attoparsec/Internal/Types.hs
+++ b/Data/Attoparsec/Internal/Types.hs
@@ -72,7 +72,7 @@ instance (Show i, Show r) => Show (IResult i r) where
         (Fail t stk msg) -> showString "Fail" . f t . f stk . f msg
         (Partial _)      -> showString "Partial _"
         (Done t r)       -> showString "Done" . f t . f r 
-      where f x = showString " " . showsPrec 11 x 
+      where f x = showChar ' ' . showsPrec 11 x 
 
 instance (NFData i, NFData r) => NFData (IResult i r) where
     rnf (Fail t stk msg) = rnf t `seq` rnf stk `seq` rnf msg

--- a/Data/Attoparsec/Internal/Types.hs
+++ b/Data/Attoparsec/Internal/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, FlexibleInstances, GeneralizedNewtypeDeriving, OverloadedStrings,
+{-# LANGUAGE BangPatterns, GeneralizedNewtypeDeriving, OverloadedStrings,
     Rank2Types, RecordWildCards, TypeFamilies #-}
 -- |
 -- Module      :  Data.Attoparsec.Internal.Types
@@ -65,10 +65,14 @@ data IResult i r =
   | Done i r
     -- ^ The parse succeeded.  The @i@ parameter is the input that had
     -- not yet been consumed (if any) when the parse succeeded.
-    deriving (Show)
-    
-instance Show (i -> IResult i r) where
-    show _ = "_"
+
+instance (Show i, Show r) => Show (IResult i r) where
+    showsPrec d ir = showParen (d > 10) $
+      case ir of
+        (Fail t stk msg) -> showString "Fail" . f t . f stk . f msg
+        (Partial _)      -> showString "Partial _"
+        (Done t r)       -> showString "Done" . f t . f r 
+      where f s = showString " " . showsPrec 11 s 
 
 instance (NFData i, NFData r) => NFData (IResult i r) where
     rnf (Fail t stk msg) = rnf t `seq` rnf stk `seq` rnf msg

--- a/Data/Attoparsec/Internal/Types.hs
+++ b/Data/Attoparsec/Internal/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, GeneralizedNewtypeDeriving, OverloadedStrings,
+{-# LANGUAGE BangPatterns, FlexibleInstances, GeneralizedNewtypeDeriving, OverloadedStrings,
     Rank2Types, RecordWildCards, TypeFamilies #-}
 -- |
 -- Module      :  Data.Attoparsec.Internal.Types
@@ -65,12 +65,10 @@ data IResult i r =
   | Done i r
     -- ^ The parse succeeded.  The @i@ parameter is the input that had
     -- not yet been consumed (if any) when the parse succeeded.
-
-instance (Show i, Show r) => Show (IResult i r) where
-    show (Fail t stk msg) =
-      unwords [ "Fail", show t, show stk, show msg]
-    show (Partial _)          = "Partial _"
-    show (Done t r)       = unwords ["Done", show t, show r]
+    deriving (Show)
+    
+instance Show (i -> IResult i r) where
+    show _ = "_"
 
 instance (NFData i, NFData r) => NFData (IResult i r) where
     rnf (Fail t stk msg) = rnf t `seq` rnf stk `seq` rnf msg

--- a/Data/Attoparsec/Internal/Types.hs
+++ b/Data/Attoparsec/Internal/Types.hs
@@ -72,7 +72,7 @@ instance (Show i, Show r) => Show (IResult i r) where
         (Fail t stk msg) -> showString "Fail" . f t . f stk . f msg
         (Partial _)      -> showString "Partial _"
         (Done t r)       -> showString "Done" . f t . f r 
-      where f s = showString " " . showsPrec 11 s 
+      where f x = showString " " . showsPrec 11 x 
 
 instance (NFData i, NFData r) => NFData (IResult i r) where
     rnf (Fail t stk msg) = rnf t `seq` rnf stk `seq` rnf msg

--- a/Data/Attoparsec/Internal/Types.hs
+++ b/Data/Attoparsec/Internal/Types.hs
@@ -71,8 +71,8 @@ instance (Show i, Show r) => Show (IResult i r) where
       case ir of
         (Fail t stk msg) -> showString "Fail" . f t . f stk . f msg
         (Partial _)      -> showString "Partial _"
-        (Done t r)       -> showString "Done" . f t . f r 
-      where f x = showChar ' ' . showsPrec 11 x 
+        (Done t r)       -> showString "Done" . f t . f r
+      where f x = showChar ' ' . showsPrec 11 x
 
 instance (NFData i, NFData r) => NFData (IResult i r) where
     rnf (Fail t stk msg) = rnf t `seq` rnf stk `seq` rnf msg

--- a/Data/Attoparsec/Text/FastSet.hs
+++ b/Data/Attoparsec/Text/FastSet.hs
@@ -32,7 +32,7 @@ module Data.Attoparsec.Text.FastSet
 
 import Data.Bits ((.|.), (.&.), shiftR)
 import Data.Function (on)
-import Data.List (sort, sortBy)
+import Data.List (sort, sortBy, foldl')
 import qualified Data.Array.Base as AB
 import qualified Data.Array.Unboxed as A
 import qualified Data.Text as T

--- a/Data/Attoparsec/Text/FastSet.hs
+++ b/Data/Attoparsec/Text/FastSet.hs
@@ -32,7 +32,7 @@ module Data.Attoparsec.Text.FastSet
 
 import Data.Bits ((.|.), (.&.), shiftR)
 import Data.Function (on)
-import Data.List (sort, sortBy, foldl')
+import Data.List (sort, sortBy)
 import qualified Data.Array.Base as AB
 import qualified Data.Array.Unboxed as A
 import qualified Data.Text as T
@@ -92,8 +92,12 @@ fromList s = FastSet (AB.listArray (0, length interleaved - 1) interleaved)
                       entries
 
 ordNub :: Eq a => [a] -> [a]
-ordNub [] = []
-ordNub (x:xs) = foldl' (\ys@(y:_) z -> if y == z then ys else z:ys) [x] xs
+ordNub []     = []
+ordNub (y:ys) = go y ys
+  where go x (z:zs)
+          | x == z    = go x zs
+          | otherwise = x : go z zs
+        go x []       = [x]
 
 set :: T.Text -> FastSet
 set = fromList . T.unpack

--- a/Data/Attoparsec/Text/FastSet.hs
+++ b/Data/Attoparsec/Text/FastSet.hs
@@ -92,12 +92,8 @@ fromList s = FastSet (AB.listArray (0, length interleaved - 1) interleaved)
                       entries
 
 ordNub :: Eq a => [a] -> [a]
-ordNub []     = []
-ordNub (y:ys) = go y ys
-  where go x (z:zs)
-          | x == z    = go x zs
-          | otherwise = x : go z zs
-        go x []       = [x]
+ordNub [] = []
+ordNub (x:xs) = foldl' (\ys@(y:_) z -> if y == z then ys else z:ys) [x] xs
 
 set :: T.Text -> FastSet
 set = fromList . T.unpack

--- a/Data/Attoparsec/Text/Lazy.hs
+++ b/Data/Attoparsec/Text/Lazy.hs
@@ -56,11 +56,6 @@ data Result r = Fail Text [String] String
               -- the parse succeeded.
     deriving (Show)
 
-instance Show r => Show (Result r) where
-    show (Fail bs stk msg) =
-        "Fail " ++ show bs ++ " " ++ show stk ++ " " ++ show msg
-    show (Done bs r)       = "Done " ++ show bs ++ " " ++ show r
-
 instance NFData r => NFData (Result r) where
     rnf (Fail bs ctxs msg) = rnf bs `seq` rnf ctxs `seq` rnf msg
     rnf (Done bs r)        = rnf bs `seq` rnf r

--- a/Data/Attoparsec/Text/Lazy.hs
+++ b/Data/Attoparsec/Text/Lazy.hs
@@ -54,6 +54,7 @@ data Result r = Fail Text [String] String
               -- ^ The parse succeeded.  The 'ByteString' is the
               -- input that had not yet been consumed (if any) when
               -- the parse succeeded.
+    deriving (Show)
 
 instance Show r => Show (Result r) where
     show (Fail bs stk msg) =


### PR DESCRIPTION
This tidies up the Show instances for Result and IResult to ensure the result of show on these types is properly parenthesized.