### PR TITLE
Fix Parser type documentation

### DIFF
--- a/Data/Attoparsec/Internal/Types.hs
+++ b/Data/Attoparsec/Internal/Types.hs
@@ -83,8 +83,8 @@ instance Functor (IResult i) where
     fmap f (Partial k)      = Partial (fmap f . k)
     fmap f (Done t r)   = Done t (f r)
 
--- | The core parser type.  This is parameterised over the types @i@
--- of string being processed and @t@ of internal state representation.
+-- | The core parser type.  This is parameterised over the type @i@
+-- of string being processed.
 --
 -- This type is an instance of the following classes:
 --


### PR DESCRIPTION
I noticed when perusing hackage that a missing type parameter `t` is referenced in the docs.