### PR TITLE
Add tranformers to benchmarks

### DIFF
--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -146,6 +146,7 @@ benchmark benchmarks
     parsec >= 3.1.2,
     scientific,
     text >= 1.1.1.0,
+    transformers,
     unordered-containers,
     vector
 


### PR DESCRIPTION
Fixes:

```
..../attoparsec/Data/Attoparsec/Zepto.hs:41:8:
    Could not find module ‘Control.Monad.IO.Class’
    It is a member of the hidden package
‘transformers-0.4.2.0@trans_3eG64VdP2vzGjP6wJiCp5X’.
    Perhaps you need to add ‘transformers’ to the build-depends in your
.cabal file.
    Use -v to see a list of the files searched for.
```