### PR TITLE
Make code future proof by adding MonadFail/Semigroup instances

### DIFF
--- a/Data/Attoparsec/ByteString/Buffer.hs
+++ b/Data/Attoparsec/ByteString/Buffer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, CPP #-}
+{-# LANGUAGE BangPatterns #-}
 -- |
 -- Module      :  Data.Attoparsec.ByteString.Buffer
 -- Copyright   :  Bryan O'Sullivan 2007-2015
@@ -57,9 +57,8 @@ import Control.Exception (assert)
 import Data.ByteString.Internal (ByteString(..), memcpy, nullForeignPtr)
 import Data.Attoparsec.Internal.Fhthagn (inlinePerformIO)
 import Data.List (foldl1')
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-#endif
+import Data.Monoid as Mon (Monoid(..))
+import Data.Semigroup (Semigroup(..))
 import Data.Word (Word8)
 import Foreign.ForeignPtr (ForeignPtr, withForeignPtr)
 import Foreign.Ptr (castPtr, plusPtr)
@@ -88,14 +87,17 @@ buffer (PS fp off len) = Buf fp off len len 0
 unbuffer :: Buffer -> ByteString
 unbuffer (Buf fp off len _ _) = PS fp off len
 
+instance Semigroup Buffer where
+    (Buf _ _ _ 0 _) <> b                    = b
+    a               <> (Buf _ _ _ 0 _)      = a
+    buf             <> (Buf fp off len _ _) = append buf fp off len
+
 instance Monoid Buffer where
     mempty = Buf nullForeignPtr 0 0 0 0
 
-    mappend (Buf _ _ _ 0 _) b        = b
-    mappend a (Buf _ _ _ 0 _)        = a
-    mappend buf (Buf fp off len _ _) = append buf fp off len
+    mappend = (<>)
 
-    mconcat [] = mempty
+    mconcat [] = Mon.mempty
     mconcat xs = foldl1' mappend xs
 
 pappend :: Buffer -> ByteString -> Buffer

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -49,6 +49,11 @@ library
     build-depends:
       bytestring < 0.10.4.0
 
+  if !impl(ghc >= 8.0)
+    -- Data.Semigroup && Control.Monad.Fail are available in base-4.9+
+    build-depends: fail == 4.9.*,
+                   semigroups >=0.16.1 && <0.19
+
   exposed-modules: Data.Attoparsec
                    Data.Attoparsec.ByteString
                    Data.Attoparsec.ByteString.Char8
@@ -111,6 +116,11 @@ test-suite tests
     transformers,
     vector
 
+  if !impl(ghc >= 8.0)
+    -- Data.Semigroup && Control.Monad.Fail are available in base-4.9+
+    build-depends: fail == 4.9.*,
+                   semigroups >=0.16.1 && <0.19
+
 benchmark benchmarks
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmarks benchmarks/warp-3.0.1.1 .
@@ -148,6 +158,11 @@ benchmark benchmarks
     text >= 1.1.1.0,
     unordered-containers,
     vector
+
+  if !impl(ghc >= 8.0)
+    -- Data.Semigroup && Control.Monad.Fail are available in base-4.9+
+    build-depends: fail == 4.9.*,
+                   semigroups >=0.16.1 && <0.19
 
 source-repository head
   type:     git


### PR DESCRIPTION
This patch makes the code future proof under the MonadFail and Semigroup
proposals by adding instances in a CPP-avoiding way.

Moreover, Monad instance definitions are refactored in a canonical form.

With this patch, attoparsec is warning free with GHC 8.0 under

  -Wall -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances

(Compilation of attorparsec with GHCs back till 7.0.4 is warning-free as well)