### PR TITLE
Optimize takeWhile and takeWhile1

### DIFF
--- a/Data/Attoparsec/Text/Buffer.hs
+++ b/Data/Attoparsec/Text/Buffer.hs
@@ -82,10 +82,12 @@ unbufferAt s (Buf arr off len _ _) =
 
 instance Monoid Buffer where
     mempty = Buf A.empty 0 0 0 0
+    {-# INLINE mempty #-}
 
     mappend (Buf _ _ _ 0 _) b = b
     mappend a (Buf _ _ _ 0 _) = a
     mappend buf (Buf arr off len _ _) = append buf arr off len
+    {-# INLINE mappend #-}
 
     mconcat [] = mempty
     mconcat xs = foldl1' mappend xs

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -71,10 +71,14 @@ main = do
      , bench "isAlpha_ascii" $ nf (ABL.parse (AC.takeWhile AC.isAlpha_ascii)) bl
      , bench "isAlpha_iso8859_15" $
        nf (ABL.parse (AC.takeWhile AC.isAlpha_iso8859_15)) bl
+     , bench "T isAlpha" $ nf (AT.parse (AT.takeWhile isAlpha)) t
+     , bench "TL isAlpha" $ nf (ATL.parse (AT.takeWhile isAlpha)) tl
      ]
    , bgroup "takeWhile1" [
        bench "isAlpha" $ nf (ABL.parse (AC.takeWhile1 isAlpha)) bl
      , bench "isAlpha_ascii" $ nf (ABL.parse (AC.takeWhile1 AC.isAlpha_ascii)) bl
+     , bench "T isAlpha" $ nf (AT.parse (AT.takeWhile1 isAlpha)) t
+     , bench "TL isAlpha" $ nf (ATL.parse (AT.takeWhile1 isAlpha)) tl
      ]
    , bench "word32LE" $ nf (AB.parse word32LE) b
    , bgroup "scan" [


### PR DESCRIPTION
Add inlined version of takeWhile and takeWhile1

Inlining these functions can improve code generation significantly when
the predicate is statically known as it avoids boxing every parsed
character. Unfortunately, marking `takeWhile` itself as `INLINEABLE`
isn't sufficient to convince GHC to inline it.

Moreover, we refactor things to avoid the allocations associated with
the chunk accumulation list unless necessary.

Previously things looked like,

    benchmarking takeWhile/T isAlpha
    time                 32.33 μs   (31.70 μs .. 33.25 μs)
                         0.994 R²   (0.988 R² .. 0.998 R²)
    mean                 33.02 μs   (32.36 μs .. 33.92 μs)
    std dev              2.687 μs   (2.086 μs .. 3.476 μs)
    variance introduced by outliers: 78% (severely inflated)

    benchmarking takeWhile/TL isAlpha
    time                 71.00 μs   (69.29 μs .. 72.83 μs)
                         0.991 R²   (0.985 R² .. 0.996 R²)
    mean                 71.60 μs   (69.94 μs .. 74.58 μs)
    std dev              7.358 μs   (5.428 μs .. 10.73 μs)
    variance introduced by outliers: 83% (severely inflated)

    benchmarking takeWhile1/T isAlpha
    time                 34.64 μs   (33.34 μs .. 36.26 μs)
                         0.989 R²   (0.985 R² .. 0.994 R²)
    mean                 34.93 μs   (34.04 μs .. 35.91 μs)
    std dev              3.249 μs   (2.821 μs .. 3.950 μs)
    variance introduced by outliers: 82% (severely inflated)

    benchmarking takeWhile1/TL isAlpha
    time                 68.30 μs   (66.59 μs .. 70.39 μs)
                         0.994 R²   (0.991 R² .. 0.998 R²)
    mean                 67.84 μs   (66.53 μs .. 69.77 μs)
    std dev              5.139 μs   (3.444 μs .. 7.793 μs)
    variance introduced by outliers: 73% (severely inflated)

Now things look like,

    benchmarking takeWhile/T isAlpha
    time                 12.22 μs   (12.16 μs .. 12.31 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 12.29 μs   (12.23 μs .. 12.36 μs)
    std dev              222.0 ns   (180.4 ns .. 280.2 ns)
    variance introduced by outliers: 16% (moderately inflated)

    benchmarking takeWhile/TL isAlpha
    time                 43.13 μs   (42.77 μs .. 43.58 μs)
                         0.999 R²   (0.998 R² .. 1.000 R²)
    mean                 43.28 μs   (42.85 μs .. 44.06 μs)
    std dev              1.894 μs   (1.267 μs .. 3.137 μs)
    variance introduced by outliers: 48% (moderately inflated)

    benchmarking takeWhile1/T isAlpha
    time                 13.37 μs   (13.22 μs .. 13.57 μs)
                         0.999 R²   (0.998 R² .. 0.999 R²)
    mean                 13.29 μs   (13.14 μs .. 13.44 μs)
    std dev              536.0 ns   (463.2 ns .. 641.2 ns)
    variance introduced by outliers: 48% (moderately inflated)

    benchmarking takeWhile1/TL isAlpha
    time                 42.33 μs   (42.18 μs .. 42.59 μs)
                         0.999 R²   (0.998 R² .. 0.999 R²)
    mean                 43.72 μs   (43.22 μs .. 44.45 μs)
    std dev              1.957 μs   (1.491 μs .. 2.486 μs)
    variance introduced by outliers: 50% (moderately inflated)

Moreover, this produces a similar >3x speedup in an HTML5 parser that I
have.
