### PR TITLE
Inline and refactor Text's takeWhile and takeWhile1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
     - env: CABALVER=1.22 GHCVER=7.10.3
       compiler: ": #GHC 7.10.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,6 @@ script:
  - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests)
  - cabal test
- - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 
 # Check that the resulting source distribution can be built & installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.0.1
-      compiler: ": #GHC 7.0.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.1], sources: [hvr-ghc]}}
-    - env: CABALVER=1.16 GHCVER=7.2.1
-      compiler: ": #GHC 7.2.1"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.1], sources: [hvr-ghc]}}
     - env: CABALVER=1.16 GHCVER=7.4.2
       compiler: ": #GHC 7.4.2"
       addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 language: c
 sudo: false
 
+# Bryan threatens to turn off Travis-CI if he gets any email :-)
+notifications:
+  email: false
+
 cache:
   directories:
     - $HOME/.cabsnap

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,91 @@
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.16 GHCVER=7.0.1
+      compiler: ": #GHC 7.0.1"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.16 GHCVER=7.2.1
+      compiler: ": #GHC 7.2.1"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.1], sources: [hvr-ghc]}}
+    - env: CABALVER=1.16 GHCVER=7.4.2
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.16 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/Data/Attoparsec/Text/Buffer.hs
+++ b/Data/Attoparsec/Text/Buffer.hs
@@ -82,10 +82,12 @@ unbufferAt s (Buf arr off len _ _) =
 
 instance Monoid Buffer where
     mempty = Buf A.empty 0 0 0 0
+    {-# INLINE mempty #-}
 
     mappend (Buf _ _ _ 0 _) b = b
     mappend a (Buf _ _ _ 0 _) = a
     mappend buf (Buf arr off len _ _) = append buf arr off len
+    {-# INLINE mappend #-}
 
     mconcat [] = mempty
     mconcat xs = foldl1' mappend xs

--- a/Data/Attoparsec/Text/FastSet.hs
+++ b/Data/Attoparsec/Text/FastSet.hs
@@ -1,38 +1,118 @@
+{-# LANGUAGE BangPatterns #-}
+
+------------------------------------------------------------------------------
 -- |
--- Module      :  Data.Attoparsec.Text.FastSet
--- Copyright   :  Bryan O'Sullivan 2015
+-- Module      :  Data.Attoparsec.FastSet
+-- Copyright   :  Felipe Lessa 2010, Bryan O'Sullivan 2007-2015
 -- License     :  BSD3
 --
--- Maintainer  :  bos@serpentine.com
+-- Maintainer  :  felipe.lessa@gmail.com
 -- Stability   :  experimental
 -- Portability :  unknown
 --
--- Fast set membership tests for 'Char' values.
-
+-- Fast set membership tests for 'Char' values. We test for
+-- membership using a hashtable implemented with Robin Hood
+-- collision resolution. The set representation is unboxed,
+-- and the characters and hashes interleaved, for efficiency.
+--
+--
+-----------------------------------------------------------------------------
 module Data.Attoparsec.Text.FastSet
     (
     -- * Data type
       FastSet
     -- * Construction
     , fromList
+    , set
     -- * Lookup
     , member
     -- * Handy interface
     , charClass
     ) where
 
-import qualified Data.IntSet as I
-import Data.Char (ord)
+import Data.Bits ((.|.), (.&.), shiftR)
+import Data.Function (on)
+import Data.List (sort, sortBy)
+import qualified Data.Array.Base as AB
+import qualified Data.Array.Unboxed as A
+import qualified Data.Text as T
 
-newtype FastSet = FastSet I.IntSet
+data FastSet = FastSet {
+    table :: {-# UNPACK #-} !(A.UArray Int Int)
+  , mask  :: {-# UNPACK #-} !Int
+  }
+
+data Entry = Entry {
+    key          :: {-# UNPACK #-} !Char
+  , initialIndex :: {-# UNPACK #-} !Int
+  , index        :: {-# UNPACK #-} !Int
+  }
+
+offset :: Entry -> Int
+offset e = index e - initialIndex e
+
+resolveCollisions :: [Entry] -> [Entry]
+resolveCollisions [] = []
+resolveCollisions [e] = [e]
+resolveCollisions (a:b:entries) = a' : resolveCollisions (b' : entries)
+  where (a', b')
+          | index a < index b   = (a, b)
+          | offset a < offset b = (b { index=index a }, a { index=index a + 1 })
+          | otherwise           = (a, b { index=index a + 1 })
+
+pad :: Int -> [Entry] -> [Entry]
+pad = go 0
+  where -- ensure that we pad enough so that lookups beyond the
+        -- last hash in the table fall within the array
+        go !_ !m []          = replicate (max 1 m + 1) empty
+        go  k  m (e:entries) = map (const empty) [k..i - 1] ++ e :
+                               go (i + 1) (m + i - k - 1) entries
+          where i            = index e
+        empty                = Entry '\0' maxBound 0
+
+nextPowerOf2 :: Int -> Int
+nextPowerOf2 0  = 1
+nextPowerOf2 x  = go (x - 1) 1
+  where go y 32 = y + 1
+        go y k  = go (y .|. (y `shiftR` k)) $ k * 2
+
+fastHash :: Char -> Int
+fastHash = fromEnum
 
 fromList :: String -> FastSet
-fromList = FastSet . I.fromList . map ord
+fromList s = FastSet (AB.listArray (0, length interleaved - 1) interleaved)
+             mask'
+  where s'      = ordNub (sort s)
+        l       = length s'
+        mask'   = nextPowerOf2 ((5 * l) `div` 4) - 1
+        entries = pad mask' .
+                  resolveCollisions .
+                  sortBy (compare `on` initialIndex) .
+                  zipWith (\c i -> Entry c i i) s' .
+                  map ((.&. mask') . fastHash) $ s'
+        interleaved = concatMap (\e -> [fromEnum $ key e, initialIndex e])
+                      entries
+
+ordNub :: Eq a => [a] -> [a]
+ordNub []     = []
+ordNub (y:ys) = go y ys
+  where go x (z:zs)
+          | x == z    = go x zs
+          | otherwise = x : go z zs
+        go x []       = [x]
+
+set :: T.Text -> FastSet
+set = fromList . T.unpack
 
 -- | Check the set for membership.
 member :: Char -> FastSet -> Bool
-member c (FastSet s) = I.member (ord c) s
-{-# INLINE member #-}
+member c a           = go (2 * i)
+  where i            = fastHash c .&. mask a
+        lookupAt j b = (i' <= i) && (c == c' || b)
+            where c' = toEnum $ AB.unsafeAt (table a) j
+                  i' = AB.unsafeAt (table a) $ j + 1
+        go j         = lookupAt j . lookupAt (j + 2) . lookupAt (j + 4) .
+                       lookupAt (j + 6) . go $ j + 8
 
 charClass :: String -> FastSet
 charClass = fromList . go

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -146,6 +146,7 @@ benchmark benchmarks
     parsec >= 3.1.2,
     scientific,
     text >= 1.1.1.0,
+    transformers,
     unordered-containers,
     vector
 

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -6,7 +6,7 @@ category:        Text, Parsing
 author:          Bryan O'Sullivan <bos@serpentine.com>
 maintainer:      Bryan O'Sullivan <bos@serpentine.com>
 stability:       experimental
-tested-with:     GHC == 7.0, GHC == 7.2, GHC == 7.4, GHC == 7.6, GHC == 7.8, GHC == 7.10
+tested-with:     GHC == 7.0.1, GHC == 7.2.1, GHC == 7.4.2, GHC ==7.6.3, GHC ==7.8.4, GHC ==7.10.3
 synopsis:        Fast combinator parsing for bytestrings and text
 cabal-version:   >= 1.8
 homepage:        https://github.com/bos/attoparsec

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -89,6 +89,7 @@ test-suite tests
                   QC.Rechunked
                   QC.Simple
                   QC.Text
+                  QC.Text.FastSet
 
   ghc-options:
     -Wall -threaded -rtsopts
@@ -100,13 +101,12 @@ test-suite tests
     array,
     base >= 4 && < 5,
     bytestring,
-    containers,
     deepseq >= 1.1,
     QuickCheck >= 2.7,
     quickcheck-unicode,
     scientific,
-    test-framework >= 0.8.0.2,
-    test-framework-quickcheck2 >= 0.3.0.3,
+    tasty >= 0.11,
+    tasty-quickcheck >= 0.8,
     text,
     transformers,
     vector
@@ -136,7 +136,6 @@ benchmark benchmarks
     base == 4.*,
     bytestring >= 0.10.4.0,
     case-insensitive,
-    containers,
     criterion >= 1.0,
     deepseq >= 1.1,
     directory,

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -71,10 +71,14 @@ main = do
      , bench "isAlpha_ascii" $ nf (ABL.parse (AC.takeWhile AC.isAlpha_ascii)) bl
      , bench "isAlpha_iso8859_15" $
        nf (ABL.parse (AC.takeWhile AC.isAlpha_iso8859_15)) bl
+     , bench "T isAlpha" $ nf (AT.parse (AT.takeWhile isAlpha)) t
+     , bench "TL isAlpha" $ nf (ATL.parse (AT.takeWhile isAlpha)) tl
      ]
    , bgroup "takeWhile1" [
        bench "isAlpha" $ nf (ABL.parse (AC.takeWhile1 isAlpha)) bl
      , bench "isAlpha_ascii" $ nf (ABL.parse (AC.takeWhile1 AC.isAlpha_ascii)) bl
+     , bench "T isAlpha" $ nf (AT.parse (AT.takeWhile1 isAlpha)) t
+     , bench "TL isAlpha" $ nf (ATL.parse (AT.takeWhile1 isAlpha)) tl
      ]
    , bench "word32LE" $ nf (AB.parse word32LE) b
    , bgroup "scan" [

--- a/benchmarks/TextFastSet.hs
+++ b/benchmarks/TextFastSet.hs
@@ -62,7 +62,9 @@ resolveCollisions (a:b:entries) = a' : resolveCollisions (b' : entries)
 
 pad :: Int -> [Entry] -> [Entry]
 pad = go 0
-  where go !_ !m []          = replicate (max 1 m) empty
+  where -- ensure that we pad enough so that lookups beyond the
+        -- last hash in the table fall within the array
+        go !_ !m []          = replicate (max 1 m + 1) empty
         go  k  m (e:entries) = map (const empty) [k..i - 1] ++ e :
                                go (i + 1) (m + i - k - 1) entries
           where i            = index e

--- a/benchmarks/attoparsec-benchmarks.cabal
+++ b/benchmarks/attoparsec-benchmarks.cabal
@@ -17,6 +17,7 @@ executable attoparsec-benchmarks
     Numbers
     Network.Wai.Handler.Warp.ReadInt
     Sets
+    TextFastSet
     Warp
   hs-source-dirs: .. . warp-3.0.1.1
   ghc-options: -O2 -Wall -rtsopts

--- a/tests/QC.hs
+++ b/tests/QC.hs
@@ -6,11 +6,11 @@ import qualified QC.ByteString as ByteString
 import qualified QC.Combinator as Combinator
 import qualified QC.Simple as Simple
 import qualified QC.Text as Text
-import Test.Framework (defaultMain, testGroup)
+import Test.Tasty (defaultMain, testGroup)
 
 main = defaultMain tests
 
-tests = [
+tests = testGroup "tests" [
     testGroup "bs" ByteString.tests
   , testGroup "buf" Buffer.tests
   , testGroup "combinator" Combinator.tests

--- a/tests/QC/Buffer.hs
+++ b/tests/QC/Buffer.hs
@@ -8,8 +8,8 @@ import Control.Applicative ((<$>))
 import Data.Monoid (Monoid(mconcat))
 #endif
 import QC.Common ()
-import Test.Framework (Test)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
 import Test.QuickCheck
 import qualified Data.Attoparsec.ByteString.Buffer as BB
 import qualified Data.Attoparsec.Text.Buffer as BT
@@ -82,7 +82,7 @@ t_dropWord16 (BP _ts t buf) = do
   i <- choose (0, T.lengthWord16 t)
   return $ T.dropWord16 i t === BT.dropWord16 i buf
 
-tests :: [Test]
+tests :: [TestTree]
 tests = [
     testProperty "b_unbuffer" b_unbuffer
   , testProperty "t_unbuffer" t_unbuffer

--- a/tests/QC/ByteString.hs
+++ b/tests/QC/ByteString.hs
@@ -9,8 +9,8 @@ import Data.Int (Int64)
 import Data.Word (Word8)
 import Prelude hiding (take, takeWhile)
 import QC.Common (ASCII(..), liftOp, parseBS, toStrictBS)
-import Test.Framework (Test)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
 import Test.QuickCheck
 import qualified Data.Attoparsec.ByteString as P
 import qualified Data.Attoparsec.ByteString.Char8 as P8
@@ -155,7 +155,7 @@ nonmembers :: [Word8] -> [Word8] -> Property
 nonmembers s s' = property . not . any (`S.memberWord8` set) $ filter (not . (`elem` s)) s'
     where set = S.fromList s
 
-tests :: [Test]
+tests :: [TestTree]
 tests = [
       testProperty "anyWord8" anyWord8
     , testProperty "endOfInput" endOfInput

--- a/tests/QC/Combinator.hs
+++ b/tests/QC/Combinator.hs
@@ -8,8 +8,8 @@ import Control.Applicative ((<*>), (<$>), (<*), (*>))
 import Data.Maybe (fromJust, isJust)
 import Data.Word (Word8)
 import QC.Common (Repack, parseBS, repackBS, toLazyBS)
-import Test.Framework (Test)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
 import Test.QuickCheck
 import qualified Data.Attoparsec.ByteString.Char8 as P
 import qualified Data.Attoparsec.Combinator as C
@@ -43,7 +43,7 @@ match n (NonNegative x) (NonNegative y) rs =
             B8.replicate x 'x', B8.pack (show n), B8.replicate y 'y'
           ]
 
-tests :: [Test]
+tests :: [TestTree]
 tests = [
     testProperty "choice" choice
   , testProperty "count" count

--- a/tests/QC/Simple.hs
+++ b/tests/QC/Simple.hs
@@ -10,8 +10,8 @@ import Data.ByteString (ByteString)
 import Data.List (foldl')
 import Data.Maybe (fromMaybe)
 import QC.Rechunked (rechunkBS)
-import Test.Framework (Test)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
 import Test.QuickCheck (Property, counterexample, forAll)
 import qualified Data.Attoparsec.ByteString.Char8 as A
 
@@ -31,7 +31,7 @@ parse :: A.Parser r -> [ByteString] -> A.Result r
 parse p (x:xs) = foldl' A.feed (A.parse p x) xs
 parse p []     = A.parse p ""
 
-tests :: [Test]
+tests :: [TestTree]
 tests = [
       testProperty "issue75" t_issue75
   ]

--- a/tests/QC/Text.hs
+++ b/tests/QC/Text.hs
@@ -8,8 +8,9 @@ import Control.Applicative ((<*>), (<$>))
 import Data.Int (Int64)
 import Prelude hiding (take, takeWhile)
 import QC.Common (liftOp, parseT)
-import Test.Framework (Test)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import qualified QC.Text.FastSet as FastSet
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
 import Test.QuickCheck
 import qualified Data.Attoparsec.Text as P
 import qualified Data.Attoparsec.Text.Lazy as PL
@@ -160,7 +161,7 @@ nonmembers :: String -> String -> Property
 nonmembers s s' = property . not . any (`S.member` set) $ filter (not . (`elem` s)) s'
     where set = S.fromList s
 
-tests :: [Test]
+tests :: [TestTree]
 tests = [
       testProperty "anyChar" anyChar
     , testProperty "asciiCI" asciiCI
@@ -188,4 +189,5 @@ tests = [
     , testProperty "takeWhile1_empty" takeWhile1_empty
     , testProperty "members" members
     , testProperty "nonmembers" nonmembers
+    , testGroup "FastSet" FastSet.tests
   ]

--- a/tests/QC/Text/FastSet.hs
+++ b/tests/QC/Text/FastSet.hs
@@ -1,0 +1,15 @@
+module QC.Text.FastSet where
+
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.QuickCheck
+import qualified Data.Attoparsec.Text.FastSet as FastSet
+
+membershipCorrect :: String -> String -> Property
+membershipCorrect members others =
+    let fs = FastSet.fromList members
+        correct c = (c `FastSet.member` fs) == (c `elem` members)
+    in property $ all correct (members ++ others)
+
+tests :: [TestTree]
+tests = [ testProperty "membership is correct" membershipCorrect ]


### PR DESCRIPTION
Add inlined version of takeWhile and takeWhile1

Inlining these functions can improve code generation significantly when
the predicate is statically known as it avoids boxing every parsed
character. Unfortunately, marking `takeWhile` itself as `INLINEABLE`
isn't sufficient to convince GHC to inline it.

Moreover, we refactor things to avoid the allocations associated with
the chunk accumulation list unless necessary.

Previously things looked like,

    benchmarking takeWhile/T isAlpha
    time                 32.33 μs   (31.70 μs .. 33.25 μs)
                         0.994 R²   (0.988 R² .. 0.998 R²)
    mean                 33.02 μs   (32.36 μs .. 33.92 μs)
    std dev              2.687 μs   (2.086 μs .. 3.476 μs)
    variance introduced by outliers: 78% (severely inflated)

    benchmarking takeWhile/TL isAlpha
    time                 71.00 μs   (69.29 μs .. 72.83 μs)
                         0.991 R²   (0.985 R² .. 0.996 R²)
    mean                 71.60 μs   (69.94 μs .. 74.58 μs)
    std dev              7.358 μs   (5.428 μs .. 10.73 μs)
    variance introduced by outliers: 83% (severely inflated)

    benchmarking takeWhile1/T isAlpha
    time                 34.64 μs   (33.34 μs .. 36.26 μs)
                         0.989 R²   (0.985 R² .. 0.994 R²)
    mean                 34.93 μs   (34.04 μs .. 35.91 μs)
    std dev              3.249 μs   (2.821 μs .. 3.950 μs)
    variance introduced by outliers: 82% (severely inflated)

    benchmarking takeWhile1/TL isAlpha
    time                 68.30 μs   (66.59 μs .. 70.39 μs)
                         0.994 R²   (0.991 R² .. 0.998 R²)
    mean                 67.84 μs   (66.53 μs .. 69.77 μs)
    std dev              5.139 μs   (3.444 μs .. 7.793 μs)
    variance introduced by outliers: 73% (severely inflated)

Now things look like,

    benchmarking takeWhile/T isAlpha
    time                 12.22 μs   (12.16 μs .. 12.31 μs)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 12.29 μs   (12.23 μs .. 12.36 μs)
    std dev              222.0 ns   (180.4 ns .. 280.2 ns)
    variance introduced by outliers: 16% (moderately inflated)

    benchmarking takeWhile/TL isAlpha
    time                 43.13 μs   (42.77 μs .. 43.58 μs)
                         0.999 R²   (0.998 R² .. 1.000 R²)
    mean                 43.28 μs   (42.85 μs .. 44.06 μs)
    std dev              1.894 μs   (1.267 μs .. 3.137 μs)
    variance introduced by outliers: 48% (moderately inflated)

    benchmarking takeWhile1/T isAlpha
    time                 13.37 μs   (13.22 μs .. 13.57 μs)
                         0.999 R²   (0.998 R² .. 0.999 R²)
    mean                 13.29 μs   (13.14 μs .. 13.44 μs)
    std dev              536.0 ns   (463.2 ns .. 641.2 ns)
    variance introduced by outliers: 48% (moderately inflated)

    benchmarking takeWhile1/TL isAlpha
    time                 42.33 μs   (42.18 μs .. 42.59 μs)
                         0.999 R²   (0.998 R² .. 0.999 R²)
    mean                 43.72 μs   (43.22 μs .. 44.45 μs)
    std dev              1.957 μs   (1.491 μs .. 2.486 μs)
    variance introduced by outliers: 50% (moderately inflated)

Moreover, this produces a similar >3x speedup in an HTML5 parser that I
have.
