### PR TITLE
Make cabal sdist package up the benchmarks correctly

### DIFF
--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -21,6 +21,7 @@ extra-source-files:
     benchmarks/*.cabal
     benchmarks/*.hs
     benchmarks/*.txt
+    benchmarks/json-data/*.json
     benchmarks/Makefile
     benchmarks/med.txt.bz2
     changelog.md
@@ -122,6 +123,8 @@ benchmark benchmarks
     HeadersByteString.Atto
     HeadersText
     Links
+    Network.Wai.Handler.Warp.ReadInt
+    Network.Wai.Handler.Warp.RequestHeader
     Numbers
     Sets
     TextFastSet
@@ -136,6 +139,7 @@ benchmark benchmarks
     base == 4.*,
     bytestring >= 0.10.4.0,
     case-insensitive,
+    containers,
     criterion >= 1.0,
     deepseq >= 1.1,
     directory,


### PR DESCRIPTION
It turns out a couple more changes are needed to make the benchmarks work correctly when obtained from Hackage—just making sure that all the modules, dependencies, and files are specified correctly so that `cabal sdist` includes everything it needs to.

See also https://github.com/iu-parfunc/sc-haskell/issues/7