### PR TITLE
Expose all the modules

### DIFF
--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -69,7 +69,7 @@ library
                    Data.Attoparsec.Text.Lazy
                    Data.Attoparsec.Types
                    Data.Attoparsec.Zepto
-  other-modules:   Data.Attoparsec.ByteString.Buffer
+                   Data.Attoparsec.ByteString.Buffer
                    Data.Attoparsec.ByteString.FastSet
                    Data.Attoparsec.ByteString.Internal
                    Data.Attoparsec.Internal.Fhthagn


### PR DESCRIPTION
It would be very useful to be able to implement other parsers, and exposing all the modules would make this easier/possible.