### PR TITLE
Correct the http benchmarks

### DIFF
--- a/benchmarks/HeadersByteString.hs
+++ b/benchmarks/HeadersByteString.hs
@@ -9,6 +9,15 @@ import qualified Data.Attoparsec.ByteString.Char8 as B
 import qualified Data.Attoparsec.ByteString.Lazy as BL
 import qualified Data.ByteString.Char8 as B
 
+-- Note: In the benchmarks for parsing an http request
+-- from a strict bytestring, we consider warp's implementation,
+-- which has highly optimized code for handling the first
+-- line in particular. It's treatment of the headers
+-- is more relaxed from the treatment they are given by the
+-- attoparsec parser benchmarked here. Consequently, it
+-- is should not be possible to match its performance since
+-- it accepts header names with disallowed characters.
+
 headers :: IO Benchmark
 headers = do
   req <- B.readFile =<< pathTo "http-request.txt"

--- a/benchmarks/HeadersByteString.hs
+++ b/benchmarks/HeadersByteString.hs
@@ -18,7 +18,7 @@ headers = do
   return $ bgroup "headers" [
       bgroup "B" [
         bench "request" $ nf (B.parseOnly request) req
-      , bench "warp" $ nfIO (parseHeaderLines [req])
+      , bench "warp" $ nfIO (parseHeaderLines (B.split '\n' req))
       , bench "response" $ nf (B.parseOnly response) resp
       ]
     , bgroup "BL" [

--- a/benchmarks/HeadersByteString/Atto.hs
+++ b/benchmarks/HeadersByteString/Atto.hs
@@ -15,8 +15,16 @@ import qualified Data.ByteString.Char8 as B
 instance NFData HttpVersion where
     rnf !_ = ()
 
+isHeaderChar :: Char -> Bool
+isHeaderChar c =
+  (c >= 'a' && c <= 'z') ||
+  (c >= 'A' && c <= 'Z') ||
+  (c >= '0' && c <= '9') ||
+  (c == '_') ||
+  (c == '-')
+
 header = do
-  name <- B.takeWhile1 (B.inClass "a-zA-Z0-9_-") <* B.char ':' <* B.skipSpace
+  name <- B.takeWhile1 isHeaderChar <* B.char ':' <* B.skipSpace
   body <- bodyLine
   return (name, body)
 

--- a/benchmarks/http-request.txt
+++ b/benchmarks/http-request.txt
@@ -1,14 +1,9 @@
 GET / HTTP/1.1
 Host: twitter.com
-Accept: text/html, application/xhtml+xml, application/xml; q=0.9,
-	image/webp, */*; q=0.8
+Accept: text/html, application/xhtml+xml, application/xml; q=0.9, image/webp, */*; q=0.8
 Accept-Encoding: gzip,deflate,sdch
 Accept-Language: en-GB,en-US;q=0.8,en;q=0.6
 Cache-Control: max-age=0
-Cookie: guest_id=v1%3A139; _twitter_sess=BAh7CSIKZmxhc2hJQz-e1e1;
-	__utma=43838368.452555194.1399611824.1; __utmb=43838368;
-	__utmc=43838368; __utmz=1399611824.1.1.utmcsr=(direct)|utmcmd=(none)
-User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5)
-	AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.86
-	Safari/537.36
+Cookie: guest_id=v1%3A139; _twitter_sess=BAh7CSIKZmxhc2hJQz-e1e1; __utma=43838368.452555194.1399611824.1; __utmb=43838368; __utmc=43838368; __utmz=1399611824.1.1.utmcsr=(direct)|utmcmd=(none)
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.86 Safari/537.36
 

--- a/benchmarks/http-response.txt
+++ b/benchmarks/http-response.txt
@@ -3,10 +3,8 @@ Date: Fri, 09 May 2014 04:24:57 GMT
 Expires: -1
 Cache-Control: private, max-age=0
 Content-Type: text/html; charset=ISO-8859-1
-Set-Cookie: PREF=ID=1a871afc4240db5e:FF:LM=1399609497:S=e5MZ0itEekjVwNcU;
-	expires=Sun, 08-May-2016 04:24:57 GMT; path=/; domain=.google.com
-Set-Cookie: NID=67=-WlfaDG6VSEPk7abAjrK98HBSoCD2ID6JKkUR95tEumzDmg7Fc8pSQ8;
-	expires=Sat, 08-Nov-2014 04:24:57 GMT; path=/; domain=.google.com; HttpOnly
+Set-Cookie: PREF=ID=1a871afc4240db5e:FF:LM=1399609497:S=e5MZ0itEekjVwNcU; expires=Sun, 08-May-2016 04:24:57 GMT; path=/; domain=.google.com
+Set-Cookie: NID=67=-WlfaDG6VSEPk7abAjrK98HBSoCD2ID6JKkUR95tEumzDmg7Fc8pSQ8; expires=Sat, 08-Nov-2014 04:24:57 GMT; path=/; domain=.google.com; HttpOnly
 P3P: CP="This is not a P3P policy! See http://www.google.com/support/accounts/bin/answer.py?hl=en&answer=151657 for more info."
 Server: gws
 X-XSS-Protection: 1; mode=block


### PR DESCRIPTION
There two two unrelated issues with them. The first was that the samples had extra newline breaks in them which would cause the request and the response to be parsed incorrectly. The second was that the warp request parser was used incorrectly. It needs to be fed a list of bytestring that has already been split on newlines. The results of the changes are that the request parsers for both warp and attoparsec are significantly slower. The warp one is about 15x slower than it previously was because it previously did almost no work. It is not totally clear why the attoparsec one is slower, but it is 3x slower than it previously was.