### PR TITLE
Remove unnecessary hiding getChar

### DIFF
--- a/Data/Attoparsec/Internal/Types.hs
+++ b/Data/Attoparsec/Internal/Types.hs
@@ -39,7 +39,7 @@ import Data.ByteString.Internal (w2c)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Unsafe (Iter(..))
-import Prelude hiding (getChar, succ)
+import Prelude hiding (succ)
 import qualified Data.Attoparsec.ByteString.Buffer as B
 import qualified Data.Attoparsec.Text.Buffer as T
 


### PR DESCRIPTION
Just a small style fix that `hiding (getChar)` is unnecessary in `Internal.Types`