### PR TITLE
MonadFail compatibility with GHC 8.8.

### DIFF
--- a/Data/Attoparsec/Internal/Types.hs
+++ b/Data/Attoparsec/Internal/Types.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, GeneralizedNewtypeDeriving, OverloadedStrings,
-    Rank2Types, RecordWildCards, TypeFamilies #-}
+    Rank2Types, RecordWildCards, TypeFamilies, CPP #-}
 -- |
 -- Module      :  Data.Attoparsec.Internal.Types
 -- Copyright   :  Bryan O'Sullivan 2007-2015
@@ -136,8 +136,10 @@ instance Mon.Monoid More where
     mempty  = Incomplete
 
 instance Monad (Parser i) where
+#if !MIN_VERSION_base(4,13,0)
     fail = Fail.fail
     {-# INLINE fail #-}
+#endif
 
     return = App.pure
     {-# INLINE return #-}

--- a/Data/Attoparsec/Zepto.hs
+++ b/Data/Attoparsec/Zepto.hs
@@ -92,8 +92,10 @@ instance Monad m => Monad (ZeptoT m) where
         Fail err -> return (Fail err)
     {-# INLINE (>>=) #-}
 
+#if !MIN_VERSION_base(4,13,0)
     fail = Fail.fail
     {-# INLINE fail #-}
+#endif
 
 instance Monad m => Fail.MonadFail (ZeptoT m) where
     fail msg = Parser $ \_ -> return (Fail msg)


### PR DESCRIPTION
With this, I am able to build under the alpha release of GHC 8.8.1.