### PR TITLE
Improve ByteString Buffer's Append in One Case

### DIFF
--- a/Data/Attoparsec/ByteString/Buffer.hs
+++ b/Data/Attoparsec/ByteString/Buffer.hs
@@ -108,30 +108,35 @@ append :: Buffer -> ForeignPtr a -> Int -> Int -> Buffer
 append (Buf fp0 off0 len0 cap0 gen0) !fp1 !off1 !len1 =
   inlinePerformIO . withForeignPtr fp0 $ \ptr0 ->
     withForeignPtr fp1 $ \ptr1 -> do
-      let genSize = sizeOf (0::Int)
-          newlen  = len0 + len1
+      let genSize      = sizeOf (0::Int)
+          newlen       = len0 + len1
+          allocAndCopy = do
+            let newcap = newlen * 2
+            fp <- mallocPlainForeignPtrBytes (newcap + genSize)
+            withForeignPtr fp $ \ptr_ -> do
+              let ptr    = ptr_ `plusPtr` genSize
+                  newgen = 1
+              poke (castPtr ptr_) newgen
+              memcpy ptr (ptr0 `plusPtr` off0) (fromIntegral len0)
+              memcpy (ptr `plusPtr` len0) (ptr1 `plusPtr` off1)
+                     (fromIntegral len1)
+              return (Buf fp genSize newlen newcap newgen)
       gen <- if gen0 == 0
              then return 0
              else peek (castPtr ptr0)
-      if gen == gen0 && newlen <= cap0
-        then do
-          let newgen = gen + 1
-          poke (castPtr ptr0) newgen
-          memcpy (ptr0 `plusPtr` (off0+len0))
-                 (ptr1 `plusPtr` off1)
-                 (fromIntegral len1)
-          return (Buf fp0 off0 newlen cap0 newgen)
-        else do
-          let newcap = newlen * 2
-          fp <- mallocPlainForeignPtrBytes (newcap + genSize)
-          withForeignPtr fp $ \ptr_ -> do
-            let ptr    = ptr_ `plusPtr` genSize
-                newgen = 1
-            poke (castPtr ptr_) newgen
-            memcpy ptr (ptr0 `plusPtr` off0) (fromIntegral len0)
-            memcpy (ptr `plusPtr` len0) (ptr1 `plusPtr` off1)
-                   (fromIntegral len1)
-            return (Buf fp genSize newlen newcap newgen)
+      if gen /= gen0
+        then allocAndCopy
+        else if len0 == cap0 && ptr0 == (castPtr ptr1) && off0+len0 == off1
+          then return (Buf fp0 off0 newlen newlen gen0)
+          else if newlen <= cap0
+            then do
+              let newgen = gen + 1
+              poke (castPtr ptr0) newgen
+              memcpy (ptr0 `plusPtr` (off0+len0))
+                     (ptr1 `plusPtr` off1)
+                     (fromIntegral len1)
+              return (Buf fp0 off0 newlen cap0 newgen)
+            else allocAndCopy
 
 length :: Buffer -> Int
 length (Buf _ _ len _ _) = len


### PR DESCRIPTION
# Improve ByteString Buffer's Append in One Case

## the Case

When the appended ByteString is placed just after the Buffer and the len and cap of the Buffer are the same, you only have to expand Buffer.

```
            v- ptr0
buffer:     |..........|----------|
             <- off0 -> <- len0 ->
                        <- cap0 ->

                 v- ptr1
bytestring:      |................|----------|
                  <---- off1 ----> <- len1 ->

new         v- ptr
buffer:     |..........|---------------------|
             <- off --> <------- len ------->
                        <------- cap ------->
```

## Generation

No need to increment gen, because

- if the ByteString which is tried to be appended secondly is placed just after the Buffer too, the area of the previously appended ByteString is already overwritten.
- otherwise malloc and memcpy are necessary, because there are no free space in the Buffer.

## Text

This approach cannot be taken for Text Buffer, I think. 