### PR TITLE
Import unsafeCoerce# from GHC.Exts, not GHC.Base

### DIFF
--- a/Data/Attoparsec/ByteString/FastSet.hs
+++ b/Data/Attoparsec/ByteString/FastSet.hs
@@ -34,7 +34,7 @@ module Data.Attoparsec.ByteString.FastSet
 
 import Data.Bits ((.&.), (.|.))
 import Foreign.Storable (peekByteOff, pokeByteOff)
-import GHC.Base (Int(I#), iShiftRA#, narrow8Word#, shiftL#)
+import GHC.Exts (Int(I#), iShiftRA#, narrow8Word#, shiftL#)
 import GHC.Word (Word8(W8#))
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8

--- a/Data/Attoparsec/Internal/Fhthagn.hs
+++ b/Data/Attoparsec/Internal/Fhthagn.hs
@@ -6,7 +6,7 @@ module Data.Attoparsec.Internal.Fhthagn
       inlinePerformIO
     ) where
 
-import GHC.Base (realWorld#)
+import GHC.Exts (realWorld#)
 import GHC.IO (IO(IO))
 
 -- | Just like unsafePerformIO, but we inline it. Big performance gains as

--- a/Data/Attoparsec/Text/Buffer.hs
+++ b/Data/Attoparsec/Text/Buffer.hs
@@ -48,7 +48,7 @@ import Data.Text.Internal.Encoding.Utf16 (chr2)
 import Data.Text.Internal.Unsafe.Char (unsafeChr)
 import Data.Text.Unsafe (Iter(..))
 import Foreign.Storable (sizeOf)
-import GHC.Base (Int(..), indexIntArray#, unsafeCoerce#, writeIntArray#)
+import GHC.Exts (Int(..), indexIntArray#, unsafeCoerce#, writeIntArray#)
 import GHC.ST (ST(..), runST)
 import Prelude hiding (length)
 import qualified Data.Text.Array as A


### PR DESCRIPTION
`attoparsec` fails to build with GHC HEAD (8.11) after [this commit](https://gitlab.haskell.org/ghc/ghc/commit/74ad75e87317196c600dfabc61aee1b87d95c214), which moves `unsafeCoerce#` from `GHC.{Base,Prim}` to `Unsafe.Coerce`:

```
[ 5 of 21] Compiling Data.Attoparsec.Text.Buffer ( Data/Attoparsec/Text/Buffer.hs, /home/rgscott/Documents/Hacking/Haskell/staging/dist-newstyle/build/x86_64-linux/ghc-8.11.0.20200222/attoparsec-0.13.2.3/build/Data/Attoparsec/Text/Buffer.o, /home/rgscott/Documents/Hacking/Haskell/staging/dist-newstyle/build/x86_64-linux/ghc-8.11.0.20200222/attoparsec-0.13.2.3/build/Data/Attoparsec/Text/Buffer.dyn_o )

Data/Attoparsec/Text/Buffer.hs:51:43: error:
    Module ‘GHC.Base’ does not export ‘unsafeCoerce#’
   |
51 | import GHC.Base (Int(..), indexIntArray#, unsafeCoerce#, writeIntArray#)
   |                                           ^^^^^^^^^^^^^
```

This patch fixes the issue by instead importing `unsafeCoerce#` from `GHC.Exts`, which has better API stability. While I was in town, I went ahead and switched all other `GHC.Base` imports to `GHC.Exts` to make the code future-proof against other `GHC.Base` API changes in the future.