### PR TITLE
Support bytestring-0.11

### DIFF
--- a/Data/Attoparsec/ByteString/Internal.hs
+++ b/Data/Attoparsec/ByteString/Internal.hs
@@ -75,6 +75,7 @@ import Data.Attoparsec.ByteString.Buffer (Buffer, buffer)
 import Data.Attoparsec.ByteString.FastSet (charClass, memberWord8)
 import Data.Attoparsec.Combinator ((<?>))
 import Data.Attoparsec.Internal
+import Data.Attoparsec.Internal.Compat
 import Data.Attoparsec.Internal.Fhthagn (inlinePerformIO)
 import Data.Attoparsec.Internal.Types hiding (Parser, Failure, Success)
 import Data.ByteString (ByteString)
@@ -303,7 +304,7 @@ scan_ :: (s -> [ByteString] -> Parser r) -> s -> (s -> Word8 -> Maybe s)
 scan_ f s0 p = go [] s0
  where
   go acc s1 = do
-    let scanner (B.PS fp off len) =
+    let scanner bs = withPS bs $ \fp off len ->
           withForeignPtr fp $ \ptr0 -> do
             let start = ptr0 `plusPtr` off
                 end   = start `plusPtr` len

--- a/Data/Attoparsec/Internal/Compat.hs
+++ b/Data/Attoparsec/Internal/Compat.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+module Data.Attoparsec.Internal.Compat where
+
+import Data.ByteString.Internal (ByteString(..))
+import Data.Word (Word8)
+import Foreign.ForeignPtr (ForeignPtr)
+
+#if MIN_VERSION_bytestring(0,11,0)
+import Data.ByteString.Internal (plusForeignPtr)
+#endif
+
+withPS :: ByteString -> (ForeignPtr Word8 -> Int -> Int -> r) -> r
+#if MIN_VERSION_bytestring(0,11,0)
+withPS (BS fp len)     kont = kont fp 0   len
+#else
+withPS (PS fp off len) kont = kont fp off len
+#endif
+{-# INLINE withPS #-}
+
+mkPS :: ForeignPtr Word8 -> Int -> Int -> ByteString
+#if MIN_VERSION_bytestring(0,11,0)
+mkPS fp off len = BS (plusForeignPtr fp off) len
+#else
+mkPS fp off len = PS fp off len
+#endif
+{-# INLINE mkPS #-}

--- a/attoparsec.cabal
+++ b/attoparsec.cabal
@@ -40,12 +40,13 @@ Flag developer
 library
   build-depends: array,
                  base >= 4.3 && < 5,
-                 bytestring,
+                 bytestring <0.12,
                  containers,
                  deepseq,
                  scientific >= 0.3.1 && < 0.4,
                  transformers >= 0.2 && (< 0.4 || >= 0.4.1.0) && < 0.6,
-                 text >= 1.1.1.3
+                 text >= 1.1.1.3,
+                 ghc-prim <0.7
   if impl(ghc < 7.4)
     build-depends:
       bytestring < 0.10.4.0
@@ -72,6 +73,7 @@ library
   other-modules:   Data.Attoparsec.ByteString.Buffer
                    Data.Attoparsec.ByteString.FastSet
                    Data.Attoparsec.ByteString.Internal
+                   Data.Attoparsec.Internal.Compat
                    Data.Attoparsec.Internal.Fhthagn
                    Data.Attoparsec.Text.Buffer
                    Data.Attoparsec.Text.FastSet


### PR DESCRIPTION
Also virtually *all* past `attoparsec` releases need `bytestring <0.11` revision:

EDIT: I made the revisions, basically adding `bytestring <0.11` to all `attoparsec` releases.

```
attoparsec-0.13.2.4  OK      OK     OK     OK     OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.13.2.3  OK      OK     OK     OK     OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.13.2.2  NO-IP   NO-IP  OK     OK     OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.13.2.1  NO-IP   NO-IP  OK     OK     OK     OK     NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP
attoparsec-0.13.2.0  NO-IP   NO-IP  OK     OK     OK     OK     NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP
attoparsec-0.13.1.0  NO-IP   NO-IP  OK     OK     OK     OK     NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP
attoparsec-0.13.0.2  NO-IP   NO-IP  NO-IP  NO-IP  OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.13.0.1  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.13.0.0  NO-IP   NO-IP  NO-IP  NO-IP  OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.12.1.6  NO-IP   NO-IP  NO-IP  NO-IP  OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.12.1.5  NO-IP   NO-IP  NO-IP  NO-IP  OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.12.1.4  NO-IP   NO-IP  NO-IP  NO-IP  OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.12.1.3  NO-IP   NO-IP  NO-IP  NO-IP  OK     OK     FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.12.1.2  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.12.1.1  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.12.1.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.12.0.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.11.3.4  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.11.3.3  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.11.3.2  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.11.3.1  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP
attoparsec-0.11.3.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.11.2.1  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.11.1.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.4.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.3.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.2.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.1.1  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.1.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.0.3  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.0.2  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.0.1  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.10.0.0  NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   NO-IP  NO-IP
attoparsec-0.9.1.2   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.9.1.1   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.9.0.0   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.8.6.1   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.8.6.0   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.8.5.3   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.8.5.2   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.8.5.1   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.8.5.0   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.8.4.0   NO-IP   NO-IP  NO-IP  NO-IP  FAIL   FAIL   FAIL    FAIL   FAIL   FAIL   FAIL   FAIL 
attoparsec-0.8.3.0   NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  FAIL 
attoparsec-0.8.2.0   NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  FAIL 
attoparsec-0.8.1.1   NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  FAIL 
attoparsec-0.8.1.0   NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  FAIL 
attoparsec-0.8.0.2   NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  FAIL 
attoparsec-0.8.0.1   NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  FAIL 
attoparsec-0.8.0.0   NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  FAIL 
attoparsec-0.7.2     NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP
attoparsec-0.7.1     NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP
attoparsec-0.6       NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP  NO-IP   NO-IP  NO-IP  NO-IP  NO-IP  NO-IP
```